### PR TITLE
session-management.md: Proposed way of handling $XDG_RUNTIME_DIR

### DIFF
--- a/src/config/session-management.md
+++ b/src/config/session-management.md
@@ -62,6 +62,8 @@ user-specific runtime files.
 Install [elogind](#elogind) as your session manager to automatically set up
 `XDG_RUNTIME_DIR`.
 
-Alternatively, manually set the environment variable through the shell. Make
-sure to create a dedicated user directory and set its permissions to `700`. A
-good default location is `/run/user/$(id -u)`.
+Alternatively, install [pam_rundir(8)](https://man.voidlinux.org/pam_rundir) and
+add it to `/etc/pam.d/login` to automatically create a $XDG_RUNTIME_DIR at login. 
+Manually setting the environment variable can be a bit cumbersome specially if you 
+need $XDG_RUNTIME_DIR at the default location of `/run/user/$(id -u)` for apps that 
+have it hardcoded. 


### PR DESCRIPTION
Manually setting `$XDG_RUNTIME_DIR` is not trivial to do while staying compliant to the XDG spec as noted in issue #635. This proposed way handles `$XDG_RUNTIME_DIR` properly without having to install `elogind` and should suggested as its alternative

<!--
Before submitting a pull request, please read [CONTRIBUTING](https://github.com/void-linux/void-docs/blob/master/CONTRIBUTING.md); pull requests that do not meet the criteria described there will not be merged. Note that this repository's CONTRIBUTING contains information specific to this repository, and is not the same as CONTRIBUTING for the void-packages repository.

We prioritise pull requests involving information specific to Void over those involving information applicable to Linux in general.
-->
